### PR TITLE
P4Pi fix: Use p4c from system path

### DIFF
--- a/hlir.py
+++ b/hlir.py
@@ -5,15 +5,12 @@
 # Copyright 2017-2020 Eotvos Lorand University, Budapest, Hungary
 
 
-import json
 import subprocess
 import os
 import os.path
 import shutil
-import tempfile
 
 from hlir16.p4node import P4Node
-from hlir16.hlir_attrs import set_additional_attrs
 
 
 def has_method(obj, method_name):


### PR DESCRIPTION
In P4Pi, p4c is installed from a debian package and all executables are available in the standard system paths. This patch allows P4Pi to use the pre-installed binaries and headers.